### PR TITLE
include cassert

### DIFF
--- a/hilbert-sort/include/hilbert-sort.h
+++ b/hilbert-sort/include/hilbert-sort.h
@@ -1,6 +1,7 @@
 #ifndef HILBERT_SORT__HILBERT_H__INCLUDED
 #define HILBERT_SORT__HILBERT_H__INCLUDED
 
+#include <cassert>
 #include <algorithm>
 #include <array>
 #include <cstdlib>


### PR DESCRIPTION
I'm getting a compile error for not including cassert

Including it in my main file locally fixes it, but it should probably be here too as this is where it's used